### PR TITLE
Fix MvxFilteringAdapter unreliability.

### DIFF
--- a/MvvmCross/Binding/Droid/Views/MvxFilteringAdapter.cs
+++ b/MvvmCross/Binding/Droid/Views/MvxFilteringAdapter.cs
@@ -68,6 +68,11 @@ namespace MvvmCross.Binding.Droid.Views
 
         private int SetConstraintAndWaitForDataChange(string newConstraint)
         {
+            if (this.PartialText == newConstraint)
+            {
+                return this.Count;
+            }
+            
             MvxTrace.Trace("Wait starting for {0}", newConstraint);
             this._dataChangedEvent.Reset();
             this.PartialText = newConstraint;


### PR DESCRIPTION
SetConstraintAndWaitForDataChange would execute twice for one input change with identical input, which would cause two waits but only one PartialText binding change. 

This prevents it from triggering events which won't resolve due to identical values.